### PR TITLE
Set lambda timeout to 90 seconds by default

### DIFF
--- a/API.md
+++ b/API.md
@@ -202,3 +202,15 @@ The SNS topic to notify when a new cert is issued.
 
 ---
 
+##### `timeout`<sup>Optional</sup> <a name="@renovosolutions/cdk-library-certbot.ICertbotProps.property.timeout"></a>
+
+```typescript
+public readonly timeout: Duration;
+```
+
+- *Type:* [`@aws-cdk/core.Duration`](#@aws-cdk/core.Duration)
+
+The timeout duration for Lambda function.
+
+---
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,10 @@ export interface ICertbotProps {
    * Insights layer ARN for your region. Defaults to US-EAST-1
    */
   insightsARN?: string;
+  /**
+   * The timeout duration for Lambda function
+   */
+  timeout?: cdk.Duration;
 }
 
 export class Certbot extends cdk.Construct {
@@ -86,6 +90,7 @@ export class Certbot extends cdk.Construct {
     }
 
     props.layers = (props.layers === undefined) ? [] : props.layers;
+    props.timeout = (props.timeout === undefined) ? cdk.Duration.seconds(90) : props.timeout;
     props.enableInsights = (props.enableInsights === undefined) ? false : props.enableInsights;
     props.insightsARN = (props.insightsARN === undefined) ? 'arn:aws:lambda:' + cdk.Stack.of(this).region + ':580247275435:layer:LambdaInsightsExtension:14' : props.insightsARN;
 
@@ -204,6 +209,7 @@ export class Certbot extends cdk.Construct {
         NOTIFICATION_SNS_ARN: props.snsTopic.topicArn,
       },
       layers: props.layers,
+      timeout: props.timeout,
     });
 
     new events.Rule(this, 'trigger', {


### PR DESCRIPTION
Local simulation takes 60 seconds so add 50% and hope for the best with the default of 90 seconds, but allow override if needed.