### PR TITLE
Use the `bucketName` instead of the `bucketArn` from the create bucket

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -202,7 +202,7 @@ export class Certbot extends cdk.Construct {
       environment: {
         LETSENCRYPT_DOMAINS: props.letsencryptDomains,
         LETSENCRYPT_EMAIL: props.letsencryptEmail,
-        CERTIFICATE_BUCKET: props.bucket.bucketArn,
+        CERTIFICATE_BUCKET: props.bucket.bucketName,
         OBJECT_PREFIX: (props.objectPrefix === undefined) ? '' : props.objectPrefix,
         REISSUE_DAYS: (props.reIssueDays === undefined) ? '30' : String(props.reIssueDays),
         PREFERRED_CHAIN: (props.preferredChain === undefined) ? 'None' : props.preferredChain,


### PR DESCRIPTION
The ARN was resulting in validation errors but the name is what we used previously.

Closes #23