### PR TITLE
ci: Fix cdk upgrade script missing package errors

### DIFF
--- a/.github/workflows/upgrade-cdk-v1.yml
+++ b/.github/workflows/upgrade-cdk-v1.yml
@@ -11,5 +11,5 @@ jobs:
         with:
           ref: v1
       - name: Run upgrade script
-        id: 'release_version'
+        id: 'upgrade_cdk_script'
         run: npm run upgrade-cdk

--- a/.github/workflows/upgrade-cdk-v2.yml
+++ b/.github/workflows/upgrade-cdk-v2.yml
@@ -11,5 +11,5 @@ jobs:
         with:
           ref: master
       - name: Run upgrade script
-        id: 'release_version'
+        id: 'upgrade_cdk_script'
         run: npm run upgrade-cdk

--- a/upgrade_cdk_version.bash
+++ b/upgrade_cdk_version.bash
@@ -19,7 +19,7 @@ if [[  $release_version == $local_version ]]; then
 else
   echo "Upgrading CDK version from $local_version to $release_version"
   sed -i "s/cdkVersion: '$local_version'/cdkVersion: '$release_version'/g" .projenrc.js
-  npx projen && jest test && yarn build
+  yarn install && npx projen && jest test && yarn build
   if [[ $? -eq 0 ]]; then
     echo "CDK version upgraded built successfully"
     git config user.name "github-actions"


### PR DESCRIPTION
Projen isn't installed, obviously, on the github actions container so need to make sure yarn install is run prior to trying to utilize projen