### PR TITLE
feat: Add ability to pass Route53 zone as target zone for setup

### DIFF
--- a/API.md
+++ b/API.md
@@ -57,18 +57,6 @@ import { CertbotProps } from '@renovosolutions/cdk-library-certbot'
 const certbotProps: CertbotProps = { ... }
 ```
 
-##### `hostedZoneNames`<sup>Required</sup> <a name="@renovosolutions/cdk-library-certbot.CertbotProps.property.hostedZoneNames"></a>
-
-```typescript
-public readonly hostedZoneNames: string[];
-```
-
-- *Type:* `string`[]
-
-Hosted zone names that will be required for DNS verification with certbot.
-
----
-
 ##### `letsencryptDomains`<sup>Required</sup> <a name="@renovosolutions/cdk-library-certbot.CertbotProps.property.letsencryptDomains"></a>
 
 ```typescript
@@ -158,6 +146,30 @@ public readonly functionName: string;
 - *Type:* `string`
 
 The name of the resulting Lambda function.
+
+---
+
+##### `hostedZoneNames`<sup>Optional</sup> <a name="@renovosolutions/cdk-library-certbot.CertbotProps.property.hostedZoneNames"></a>
+
+```typescript
+public readonly hostedZoneNames: string[];
+```
+
+- *Type:* `string`[]
+
+Hosted zone names that will be required for DNS verification with certbot.
+
+---
+
+##### `hostedZones`<sup>Optional</sup> <a name="@renovosolutions/cdk-library-certbot.CertbotProps.property.hostedZones"></a>
+
+```typescript
+public readonly hostedZones: IHostedZone[];
+```
+
+- *Type:* [`aws-cdk-lib.aws_route53.IHostedZone`](#aws-cdk-lib.aws_route53.IHostedZone)[]
+
+The hosted zones that will be required for DNS verification with certbot.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,15 +5,18 @@
 A CDK Construct Library to automate the creation and renewal of Let's Encrypt certificates.
 
 ## Features
+
 - Creates a lambda function that utilizes Certbot to request a certificate from Let's Encrypt
 - Uploads the resulting certificate data to S3 for later retrieval
 - Imports the certificate to AWS Certificate Manager for tracking expiration
 - Creates a trigger to re-run and re-new if the cert will expire in the next 30 days (customizable)
 
 ## API Doc
+
 See [API](API.md)
 
 ## References
+
 Original [gist](# Modified from original gist https://gist.github.com/arkadiyt/5d764c32baa43fc486ca16cb8488169a) that was modified for the Lambda code
 
 ## Examples
@@ -21,7 +24,8 @@ Original [gist](# Modified from original gist https://gist.github.com/arkadiyt/5
 This construct utilizes a Route 53 hosted zone lookup so it will require that your stack has [environment variables set for account and region](See https://docs.aws.amazon.com/cdk/latest/guide/environments.html for more details.).
 
 ### Typescript
-```
+
+```typescript
 import * as cdk from '@aws-cdk/core';
 import { Certbot } from '@renovosolutions/cdk-library-certbot';
 import { Architecture } from '@aws-cdk/aws-lambda';
@@ -44,10 +48,47 @@ export class CdkExampleCertsStack extends cdk.Stack {
     })
   }
 }
+```
 
+### Typescript with zone creation in the same stack
+
+```typescript
+import * as cdk from '@aws-cdk/core';
+import * as route53 from '@aws-cdk/aws_route53';
+import { Certbot } from '@renovosolutions/cdk-library-certbot';
+import { Architecture } from '@aws-cdk/aws-lambda';
+
+export class CdkExampleCertsStack extends cdk.Stack {
+  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const hostedZone = new r53.HostedZone(this, 'authZone', {
+      zoneName: 'auth.example.com',
+    });
+
+    let domains = [
+      'example.com',
+      'www.example.com',
+      'auth.example.com'
+    ]
+
+    new Certbot(this, 'cert', {
+      letsencryptDomains: domains.join(','),
+      letsencryptEmail: 'webmaster+letsencrypt@example.com',
+      hostedZoneNames: [
+        'example.com'
+      ],
+      hostedZones: [
+        hostedZone,
+      ]
+    })
+  }
+}
 ```
+
 ## Python
-```
+
+```python
 from aws_cdk import (
     core as cdk
 )

--- a/test/__snapshots__/certbot.test.ts.snap
+++ b/test/__snapshots__/certbot.test.ts.snap
@@ -193,6 +193,21 @@ Object {
                     ],
                   ],
                 },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":route53:::hostedzone/",
+                      Object {
+                        "Ref": "ZoneA5DE4B68",
+                      },
+                    ],
+                  ],
+                },
               ],
             },
           ],
@@ -362,7 +377,7 @@ Object {
     },
     "CertbottriggerImmediate08D06D4E": Object {
       "Properties": Object {
-        "ScheduleExpression": "cron(10 0 1 1 ? 2020)",
+        "ScheduleExpression": "cron(10 0 31 1 ? 2020)",
         "State": "ENABLED",
         "Targets": Array [
           Object {
@@ -396,6 +411,12 @@ Object {
         },
       },
       "Type": "AWS::Lambda::Permission",
+    },
+    "ZoneA5DE4B68": Object {
+      "Properties": Object {
+        "Name": "auth.test.local.",
+      },
+      "Type": "AWS::Route53::HostedZone",
     },
   },
   "Rules": Object {

--- a/test/__snapshots__/certbot.test.ts.snap
+++ b/test/__snapshots__/certbot.test.ts.snap
@@ -377,7 +377,7 @@ Object {
     },
     "CertbottriggerImmediate08D06D4E": Object {
       "Properties": Object {
-        "ScheduleExpression": "cron(10 0 31 1 ? 2020)",
+        "ScheduleExpression": "cron(10 0 1 1 ? 2020)",
         "State": "ENABLED",
         "Targets": Array [
           Object {


### PR DESCRIPTION
Previously creating a zone and trying to use it in the same stack would fail because CDK cant lookup a zone that does not yet exist. You can now pass a zone you created to the construct with a different prop. Construct still accepts zone name strings and verifies at least 1 zone name string or zone construct is provided.