### PR TITLE
Fix docs and snapshot after addition of architecture prop for lambda

### DIFF
--- a/API.md
+++ b/API.md
@@ -83,6 +83,23 @@ The email to associate with the Let's Encrypt certificate request.
 
 ---
 
+##### `architecture`<sup>Optional</sup> <a name="@renovosolutions/cdk-library-certbot.CertbotProps.property.architecture"></a>
+
+```typescript
+public readonly architecture: Architecture;
+```
+
+- *Type:* [`aws-cdk-lib.aws_lambda.Architecture`](#aws-cdk-lib.aws_lambda.Architecture)
+- *Default:* lambda.Architecture.X86_64
+
+The architecture for the Lambda function.
+
+This property allows you to specify the architecture type for your Lambda function.
+Supported values are 'x86_64' for the standard architecture and 'arm64' for the
+ARM architecture.
+
+---
+
 ##### `bucket`<sup>Optional</sup> <a name="@renovosolutions/cdk-library-certbot.CertbotProps.property.bucket"></a>
 
 ```typescript

--- a/test/__snapshots__/certbot.test.ts.snap
+++ b/test/__snapshots__/certbot.test.ts.snap
@@ -130,6 +130,9 @@ Object {
         "Certbot2role947EDF69",
       ],
       "Properties": Object {
+        "Architectures": Array [
+          "x86_64",
+        ],
         "Code": Object {
           "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
           "S3Key": "REMOVED-BECAUSE-WE-ARE-NOT-INTERESTED-IN-LAMBDA-CODE-HASH-IN-THIS-TEST",
@@ -448,6 +451,9 @@ Object {
         "Certbot3role650AD6C3",
       ],
       "Properties": Object {
+        "Architectures": Array [
+          "x86_64",
+        ],
         "Code": Object {
           "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
           "S3Key": "REMOVED-BECAUSE-WE-ARE-NOT-INTERESTED-IN-LAMBDA-CODE-HASH-IN-THIS-TEST",
@@ -758,6 +764,9 @@ Object {
         "Certbot4roleCDF970B1",
       ],
       "Properties": Object {
+        "Architectures": Array [
+          "x86_64",
+        ],
         "Code": Object {
           "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
           "S3Key": "REMOVED-BECAUSE-WE-ARE-NOT-INTERESTED-IN-LAMBDA-CODE-HASH-IN-THIS-TEST",
@@ -1069,6 +1078,9 @@ Object {
         "Certbot5roleF9851B9B",
       ],
       "Properties": Object {
+        "Architectures": Array [
+          "x86_64",
+        ],
         "Code": Object {
           "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
           "S3Key": "REMOVED-BECAUSE-WE-ARE-NOT-INTERESTED-IN-LAMBDA-CODE-HASH-IN-THIS-TEST",
@@ -1371,6 +1383,9 @@ Object {
         "Certbot6role1843873F",
       ],
       "Properties": Object {
+        "Architectures": Array [
+          "x86_64",
+        ],
         "Code": Object {
           "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
           "S3Key": "REMOVED-BECAUSE-WE-ARE-NOT-INTERESTED-IN-LAMBDA-CODE-HASH-IN-THIS-TEST",
@@ -1682,6 +1697,9 @@ Object {
         "VpcPrivateSubnet2RouteTableAssociationA89CAD56",
       ],
       "Properties": Object {
+        "Architectures": Array [
+          "x86_64",
+        ],
         "Code": Object {
           "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
           "S3Key": "REMOVED-BECAUSE-WE-ARE-NOT-INTERESTED-IN-LAMBDA-CODE-HASH-IN-THIS-TEST",
@@ -2168,6 +2186,9 @@ Object {
         "Certbotrole7718327E",
       ],
       "Properties": Object {
+        "Architectures": Array [
+          "x86_64",
+        ],
         "Code": Object {
           "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
           "S3Key": "REMOVED-BECAUSE-WE-ARE-NOT-INTERESTED-IN-LAMBDA-CODE-HASH-IN-THIS-TEST",


### PR DESCRIPTION
Needed to run projen and rebuild the project to make sure api docs and snapshot were up to date before publishing.